### PR TITLE
Refatorando listagem para syntax highlighting e adicionando autocompl…

### DIFF
--- a/src/components/CodeEditor.jsx
+++ b/src/components/CodeEditor.jsx
@@ -2,7 +2,7 @@ import { Box, HStack } from "@chakra-ui/react";
 import { Editor } from "@monaco-editor/react";
 import { useRef, useState } from "react";
 import LanguageSelector from "./LanguageSelector";
-import { CODE_SNIPPETS } from "../constants";
+import { CODE_SNIPPETS, KEYWORDS_DOCS_LIST } from "../constants";
 import Output from "./Output";
 
 const CodeEditor = () => {
@@ -16,17 +16,12 @@ const CodeEditor = () => {
 
         monaco.languages.register({ id: language });
 
-        const PALAVRASRESERVADAS = ['escreva', 'leia', 'aparar', 'apararFim', 'apararInicio', 'concatenar',
-            'dividir', 'fatiar', 'inclui', 'maiusculo', 'minusculo', 'substituir', 'subtexto', 'arredondarParaBaixo',
-            'arredondarParaCima', 'adicionar', 'empilhar', 'inverter', 'juntar', 'ordenar', 'remover', 'removerPrimeiro',
-            'removerUltimo', 'somar', 'tamanho', 'aleatorio', 'aleatorioEntre', 'inteiro', 'numero', 'número', 'real',
-            'texto'
-        ]
+        const KEYWORDS = KEYWORDS_DOCS_LIST.map(item => item.nome);
 
         monaco.languages.setMonarchTokensProvider(language, {
             tokenizer: {
                 root: [
-                    [new RegExp(`\\b(${PALAVRASRESERVADAS.join('|')})\\b`), "keyword"],
+                    [new RegExp(`\\b(${KEYWORDS.join('|')})\\b`), "keyword"],
                     [/\d+/, "number"],
                     [/".*?"/, "string"],
                     [/\#.*/, "comment"],
@@ -34,6 +29,36 @@ const CodeEditor = () => {
                 ],
             },
         });
+
+        function createKeywordsAutocomplete(range) {
+            return  KEYWORDS_DOCS_LIST.map((p) => ({
+              label: p.nome,
+              kind: monaco.languages.CompletionItemKind.Function,
+              documentation: p.documentacao,
+              insertText: `${p.nome}()`,
+              range
+            }));
+          }
+
+        monaco.languages.registerCompletionItemProvider(language, {
+            triggerCharacters: 'abcdefghijklmnopqrstuvwxyz'.split(''),
+          
+            provideCompletionItems: function (model, position) {
+              const word = model.getWordUntilPosition(position);
+              const range = {
+                startLineNumber: position.lineNumber,
+                endLineNumber: position.lineNumber,
+                startColumn: word.startColumn,
+                endColumn: word.endColumn
+              };
+          
+              return {
+                suggestions: createKeywordsAutocomplete(range)
+              };
+            }
+          });
+          
+
     };
 
     const onSelect = (lang) => {

--- a/src/constants.js
+++ b/src/constants.js
@@ -59,8 +59,80 @@ export const KEYWORDS_DOCS_LIST = [
         nome: 'minusculo',
         documentacao: 'Converte todos os caracteres de um texto para minúsculo',
     },
-    // {
-    //     nome: ,
-    //     documentacao: ,
-    // },
+    {
+        nome: 'substituir',
+        documentacao: 'Substitui valores textuais indicados por parâmetros, sendo o primeiro o valor a ser substituído e o segundo o valor substituto',
+    },
+    {
+        nome: 'subtexto',
+        documentacao: 'Extrai o texto entre as posições indicadas nos parâmetros',
+    },
+    {
+        nome: 'arredondarParaBaixo',
+        documentacao: 'Arredonda valor numérico para baixo.',
+    },
+    {
+        nome: 'empilhar',
+        documentacao: 'Adiciona valores a um vetor seguindo a estrutura de pilha',
+    },
+    {
+        nome: 'inverter',
+        documentacao: 'Retorna valores invertidos de um vetor',
+    },
+    {
+        nome: 'juntar',
+        documentacao: 'União de valores a partir de um separador indicado',
+    },
+    {
+        nome: 'ordenar',
+        documentacao: 'Ordena valores de um array pelo padrão crescente e/ou alfabética',
+    },
+    {
+        nome: 'remover',
+        documentacao: 'Remove o elemento indicado nos argumentos',
+    },
+    {
+        nome: 'removerPrimeiro',
+        documentacao: 'Remove o primeiro elemento de um vetor',
+    },
+    {
+        nome: 'removerUltimo',
+        documentacao: 'Remove o último elemento de um vetor',
+    },
+    {
+        nome: 'somar',
+        documentacao: 'Soma os valores de um vetor numérico',
+    },
+    {
+        nome: 'tamanho',
+        documentacao: 'Retorna o tamanho de um vetor ou texto',
+    },
+    {
+        nome: 'aleatorio',
+        documentacao: 'Retorna um valor numérico aleatório',
+    },
+    {
+        nome: 'aleatorioEntre',
+        documentacao: 'Retorna um valor numérico aleatório entre dois valores indicados nos argumentos',
+    },
+    {
+        nome: 'inteiro',
+        documentacao: 'Converte valores textuais e númericos reais para um valor númerico do tipo inteiro',
+    },
+    {
+        nome: 'numero',
+        documentacao: 'Converte valores textuais para tipo número',
+    },
+    {
+        nome: 'número',
+        documentacao: 'Converte valores textuais para tipo número',
+    },
+    {
+        nome: 'real',
+        documentacao: 'Converte valores textuais e númericos inteiros para um valor númerico do tipo real',
+    },
+    {
+        nome: 'texto',
+        documentacao: 'Converte valores para tipo texto',
+    },
 ]

--- a/src/constants.js
+++ b/src/constants.js
@@ -5,3 +5,62 @@ export const LANGUAGE_VERSION = {
 export const CODE_SNIPPETS = {
     pitugues: `escreva("Olá, Design Líquido!")\n`
 };
+
+export const KEYWORDS_DOCS_LIST = [
+    {
+        nome: 'adicionar',
+        documentacao: 'Adiciona um item à lista.'
+    }, 
+    {
+        nome: 'arredondarParaCima',
+        documentacao: 'Arredonda valor numérico para cima.'
+    },
+    {
+        nome: 'escreva',
+        documentacao: 'Método que retorna um valor textual' ,
+    },
+    {
+        nome: 'leia',
+        documentacao: 'Função de entrada para valores textuais',
+    },
+    {
+        nome: 'aparar',
+        documentacao: 'Método textual que apara as extremidades de um texto',
+    },
+    {
+        nome: 'apararFim',
+        documentacao: 'Método textual que apara o final de um texto',
+    },
+    {
+        nome: 'apararInicio',
+        documentacao: 'Método textual que apara o início de um texto',
+    },
+    {
+        nome: 'concatenar',
+        documentacao: 'Concatenação de elementos textuais',
+    },
+    {
+        nome: 'dividir',
+        documentacao: 'Gera vetor a partir de valores textuais com indicação de separador',
+    },
+    {
+        nome: 'fatiar',
+        documentacao: 'Retorna os valores de um texto de acordo com as posições indicadas',
+    },
+    {
+        nome: 'inclui',
+        documentacao: 'Verifica se o valor indicado está presente no texto',
+    },
+    {
+        nome: 'maiusculo',
+        documentacao: 'Converte todos os caracteres de um texto para maiúsculo',
+    },
+    {
+        nome: 'minusculo',
+        documentacao: 'Converte todos os caracteres de um texto para minúsculo',
+    },
+    // {
+    //     nome: ,
+    //     documentacao: ,
+    // },
+]


### PR DESCRIPTION
Refatorando listagem para syntax highlighting e adicionando autocomplete para os métodos de pituguês:

- Criação da constante uma constante KEYWORDS_DOCS_LIST no arquivo ''constants.js" para listar nome do método e sua descrição

- Remoção da constante "PALAVRASRESERVADAS", no arquivo "CodeEditor.jsx", que listava as palavras reservadas de Pituguês para aplicar o realce de sintaxe. Agora, passamos a usar a constante KEYWORDS_DOCS_LIST, mapeando os métodos pela chave 'nome'

- Desenvolvimento da função "createKeywordsAutocomplete" que mapeia as funções na constante KEYWORDS_DOCS_LIST e depois é retornada em um método do monaco que provem o autocomplete

Obs.: Ainda estou adicionando os métodos à constante KEYWORDS_DOCS_LIST com sua descrição